### PR TITLE
fix: unknown type timeline artifacts scraped as achievements

### DIFF
--- a/src/parsers/achievementParser.ts
+++ b/src/parsers/achievementParser.ts
@@ -1,0 +1,25 @@
+import {DevStoryArtifact} from '../models/devStory/devStoryArtifact';
+import {PublicArtifact} from '../models/publicArtifact';
+import {DatesParser} from './datesParser';
+import {CompetenceParser} from './competenceParser';
+
+export class AchievementParser {
+  static parse(artifact: DevStoryArtifact): PublicArtifact {
+    const [startDate] = DatesParser.parse(artifact.time);
+
+    return {
+      details: {
+        name: artifact.title,
+        description: artifact.description,
+        URL: artifact.url,
+        image: {
+          alt: artifact.logoAlt,
+          link: artifact.logo,
+        },
+      },
+      type: 'achievement',
+      publishingDate: startDate,
+      relatedCompetences: CompetenceParser.parse(artifact.tags),
+    };
+  }
+}

--- a/src/parsers/experienceParser.ts
+++ b/src/parsers/experienceParser.ts
@@ -10,6 +10,7 @@ import {DevStoryArtifact} from '../models/devStory/devStoryArtifact';
 import {PublicArtifactParser} from './publicArtifactParser';
 import {CareerPreferences} from '../models/careerPreferences';
 import {DevStoryTopsParser} from './devStory/devStoryTopsParser';
+import {AchievementParser} from './achievementParser';
 
 export class ExperienceParser {
   parse($: CheerioAPI, careerPreferences: CareerPreferences): Experience {
@@ -28,11 +29,12 @@ export class ExperienceParser {
     const projects = timeLineItems.filter(this.isProject).map(ProjectParser.parse);
     const timeLineArtifacts = timeLineItems.filter(this.isPublicArtifact).map(PublicArtifactParser.parse);
     const stackOverflowAchievements = DevStoryTopsParser.parse($, careerPreferences);
+    const unknownArtifacts = timeLineItems.filter(this.isUnknownArtifact).map(AchievementParser.parse);
 
     return {
       jobs,
       projects,
-      publicArtifacts: _.concat(timeLineArtifacts, stackOverflowAchievements),
+      publicArtifacts: _.concat(timeLineArtifacts, stackOverflowAchievements, unknownArtifacts),
     };
   }
 
@@ -44,6 +46,27 @@ export class ExperienceParser {
     return _.includes(
       ['Blogs or videos', 'Acheivement', 'Accomplishment', 'Top post', 'Assessment', 'Milestone'],
       artifact.type,
+    );
+  }
+
+  private isUnknownArtifact(artifact: DevStoryArtifact): boolean {
+    return (
+      (artifact.type as string) !== '' &&
+      !_.includes(
+        [
+          'Blogs or videos',
+          'Acheivement',
+          'Accomplishment',
+          'Top post',
+          'Assessment',
+          'Milestone',
+          'Feature or Apps',
+          'Open source',
+          'Certification',
+          'Education',
+        ],
+        artifact.type,
+      )
     );
   }
 }

--- a/src/tests/__snapshots__/devStoryScraper.test.ts.snap
+++ b/src/tests/__snapshots__/devStoryScraper.test.ts.snap
@@ -1268,6 +1268,41 @@ Original author.",
         "publishingDate": "2022-03-04",
         "type": "achievement",
       },
+      Object {
+        "details": Object {
+          "description": "I've been working full-time as a developer since 1993. In that time I've used dozens of technologies and many programming languages. The skills that transfer, though, are methodologies and design.",
+          "name": "Background",
+        },
+        "publishingDate": "2017-02-01",
+        "type": "achievement",
+      },
+      Object {
+        "details": Object {
+          "URL": "https://www.geonetric.com/operation-overnight/",
+          "description": "Built websites for local nonprofits with cross-functional teams in 24 hours (2015 and 2016).",
+          "name": "Operation Overnight",
+        },
+        "publishingDate": "2015-10-01",
+        "relatedCompetences": Array [
+          Object {
+            "name": "wordpress",
+            "type": "technology",
+          },
+          Object {
+            "name": "contact-form-7",
+            "type": "technology",
+          },
+          Object {
+            "name": "agile",
+            "type": "technology",
+          },
+          Object {
+            "name": "scrum",
+            "type": "technology",
+          },
+        ],
+        "type": "achievement",
+      },
     ],
   },
   "knowledge": Object {


### PR DESCRIPTION
This PR closes #13 

The behavior is not completely right, but we don't lose important information.

The first design decision is to ignore the Stack Overflow join achievement.

![imagen](https://user-images.githubusercontent.com/948946/158593324-1a0eff8e-aaf3-4d6f-a275-ce57e31839b1.png)

Second, some of the achievements are not achievements per se. But there is no better way to classify them without using advanced technology like ML or something similar.

![imagen](https://user-images.githubusercontent.com/948946/158593600-ec7b44d6-87e1-4b7e-9c75-da451083e104.png)
