### PR TITLE
fix: contact extracted from the about me section

### DIFF
--- a/src/devStoryScraper.ts
+++ b/src/devStoryScraper.ts
@@ -39,7 +39,7 @@ export class DevStoryScraper {
 
     const settings = this.defaultSettings();
     const aboutMe = await this.aboutMeParser.parse($);
-    const careerPreferences = this.careerPreferencesParser.parse($, url);
+    const careerPreferences = this.careerPreferencesParser.parse($, url, aboutMe);
     const experience = await this.experienceParser.parse($, careerPreferences);
     const knowledge = this.knowledgeParser.parse($);
 

--- a/src/parsers/careerPreferencesParser.ts
+++ b/src/parsers/careerPreferencesParser.ts
@@ -1,9 +1,12 @@
+import * as _ from 'lodash';
 import {CheerioAPI} from 'cheerio';
-import {CareerPreferences} from '../models/careerPreferences';
+
+import {CareerPreferences, PublicProfile} from '../models/careerPreferences';
 import {CompetenceParser} from './competenceParser';
+import {AboutMe} from '../models/aboutMe';
 
 export class CareerPreferencesParser {
-  parse($: CheerioAPI, devStoryURL: string): CareerPreferences {
+  parse($: CheerioAPI, devStoryURL: string, aboutMe: AboutMe): CareerPreferences {
     const likedTechnologies = $('div[class="user-technologies"] .timeline-item-tags .post-tag')
       .not('.disliked-tag')
       .map((i, e) => $(e).text())
@@ -15,17 +18,44 @@ export class CareerPreferencesParser {
 
     return {
       contact: {
-        publicProfiles: [
-          {
-            type: 'stackoverflow',
-            URL: devStoryURL,
-          },
-        ],
+        publicProfiles: this.getPublicProfiles(aboutMe, devStoryURL),
       },
       preferences: {
         preferredCompetences: CompetenceParser.parse(likedTechnologies),
         discardedCompetences: CompetenceParser.parse(dislikedTechnologies),
       },
     };
+  }
+
+  private getPublicProfiles(aboutMe: AboutMe, devStoryURL: string): PublicProfile[] {
+    const links = aboutMe.relevantLinks || [];
+    const publicProfiles = links
+      .map((link) => {
+        if (link.type === 'linkedin') {
+          return {
+            type: 'linkedin',
+            URL: link.URL,
+          };
+        }
+        if (link.type === 'github' || link.type === 'twitter') {
+          return {
+            type: 'other',
+            URL: link.URL,
+          };
+        }
+        return undefined;
+      })
+      .filter((publicProfile) => !_.isNil(publicProfile));
+
+    if (publicProfiles.length === 0) {
+      return [
+        {
+          type: 'stackoverflow',
+          URL: devStoryURL,
+        },
+      ];
+    }
+
+    return publicProfiles as PublicProfile[];
   }
 }

--- a/src/tests/__snapshots__/devStoryScraper.test.ts.snap
+++ b/src/tests/__snapshots__/devStoryScraper.test.ts.snap
@@ -228,8 +228,12 @@ Object {
     "contact": Object {
       "publicProfiles": Array [
         Object {
-          "URL": "https://stackoverflow.com/story/truewill",
-          "type": "stackoverflow",
+          "URL": "https://twitter.com/BillSorensen",
+          "type": "other",
+        },
+        Object {
+          "URL": "https://github.com/TrueWill",
+          "type": "other",
         },
       ],
     },
@@ -1796,8 +1800,8 @@ Object {
     "contact": Object {
       "publicProfiles": Array [
         Object {
-          "URL": "https://stackoverflow.com/story/fbuireu",
-          "type": "stackoverflow",
+          "URL": "https://github.com/fbuireu",
+          "type": "other",
         },
       ],
     },
@@ -3203,8 +3207,12 @@ Object {
     "contact": Object {
       "publicProfiles": Array [
         Object {
-          "URL": "https://stackoverflow.com/story/joeydevilla",
-          "type": "stackoverflow",
+          "URL": "https://twitter.com/AccordionGuy",
+          "type": "other",
+        },
+        Object {
+          "URL": "https://github.com/AccordionGuy",
+          "type": "other",
         },
       ],
     },
@@ -4880,8 +4888,12 @@ Object {
     "contact": Object {
       "publicProfiles": Array [
         Object {
-          "URL": "https://stackoverflow.com/story/joeydevilla-inner",
-          "type": "stackoverflow",
+          "URL": "https://twitter.com/AccordionGuy",
+          "type": "other",
+        },
+        Object {
+          "URL": "https://github.com/AccordionGuy",
+          "type": "other",
         },
       ],
     },
@@ -6553,8 +6565,12 @@ Object {
     "contact": Object {
       "publicProfiles": Array [
         Object {
-          "URL": "https://stackoverflow.com/story/ydarias",
-          "type": "stackoverflow",
+          "URL": "https://twitter.com/ydarias",
+          "type": "other",
+        },
+        Object {
+          "URL": "https://github.com/ydarias",
+          "type": "other",
         },
       ],
     },


### PR DESCRIPTION
If the user defined LinkedIn, GitHub, or Twitter URL we use that one as contact, since the dev story URL will not be longer available in a month.