### PR TITLE
feat: start date is autocompleted with the higher nearest one

### DIFF
--- a/src/fixers/jobsFixer.ts
+++ b/src/fixers/jobsFixer.ts
@@ -3,9 +3,14 @@ import * as _ from 'lodash';
 import {Job} from '../models/job';
 import {Fix} from './fix';
 import {today} from '../utils/utils';
+import {TimelineForFixer} from './timelineForFixer';
 
 export class JobsFixer {
-  fixes: Fix<Job>[] = [new StartDateFix(), new SelfEmploymentFix()];
+  private readonly fixes: Fix<Job>[];
+
+  constructor(timelineForFixer: TimelineForFixer) {
+    this.fixes = [new StartDateFix(timelineForFixer), new SelfEmploymentFix()];
+  }
 
   fix(jobs: Job[] = []): Job[] {
     return jobs.map((job) => {
@@ -18,7 +23,7 @@ export class JobsFixer {
 class StartDateFix implements Fix<Job> {
   private defaultDate: string;
 
-  constructor() {
+  constructor(private readonly timelineForFixer: TimelineForFixer) {
     this.defaultDate = process.env.SO_DEFAULT_START_DATE || today();
   }
 
@@ -27,7 +32,7 @@ class StartDateFix implements Fix<Job> {
   }
 
   execute(job: Job): Job {
-    job.roles[0].startDate = this.defaultDate;
+    job.roles[0].startDate = this.timelineForFixer.timeFor(job.roles[0].name) || this.defaultDate;
 
     return job;
   }

--- a/src/fixers/projectsFixer.ts
+++ b/src/fixers/projectsFixer.ts
@@ -3,9 +3,14 @@ import * as _ from 'lodash';
 import {Project} from '../models/project';
 import {Fix} from './fix';
 import {today} from '../utils/utils';
+import {TimelineForFixer} from './timelineForFixer';
 
 export class ProjectsFixer {
-  fixes: Fix<Project>[] = [new StartDateFix()];
+  private readonly fixes: Fix<Project>[];
+
+  constructor(timelineForFixer: TimelineForFixer) {
+    this.fixes = [new StartDateFix(timelineForFixer)];
+  }
 
   fix(projects: Project[] = []): Project[] {
     return projects.map((project) => {
@@ -18,7 +23,7 @@ export class ProjectsFixer {
 class StartDateFix implements Fix<Project> {
   private defaultDate: string;
 
-  constructor() {
+  constructor(private readonly timelineForFixer: TimelineForFixer) {
     this.defaultDate = process.env.SO_DEFAULT_START_DATE || today();
   }
 
@@ -27,7 +32,7 @@ class StartDateFix implements Fix<Project> {
   }
 
   execute(project: Project): Project {
-    project.roles[0].startDate = this.defaultDate;
+    project.roles[0].startDate = this.timelineForFixer.timeFor(project.roles[0].name) || this.defaultDate;
 
     return project;
   }

--- a/src/fixers/publicArtifactsFixer.ts
+++ b/src/fixers/publicArtifactsFixer.ts
@@ -3,9 +3,14 @@ import * as _ from 'lodash';
 import {Fix} from './fix';
 import {PublicArtifact} from '../models/publicArtifact';
 import {today} from '../utils/utils';
+import {TimelineForFixer} from './timelineForFixer';
 
 export class PublicArtifactsFixer {
-  fixes: Fix<PublicArtifact>[] = [new StartDateFix()];
+  private readonly fixes: Fix<PublicArtifact>[];
+
+  constructor(timelineForFixer: TimelineForFixer) {
+    this.fixes = [new StartDateFix(timelineForFixer)];
+  }
 
   fix(publicArtifacts: PublicArtifact[] = []): PublicArtifact[] {
     return publicArtifacts.map((publicArtifact) => {
@@ -18,7 +23,7 @@ export class PublicArtifactsFixer {
 class StartDateFix implements Fix<PublicArtifact> {
   private defaultDate: string;
 
-  constructor() {
+  constructor(private readonly timelineForFixer: TimelineForFixer) {
     this.defaultDate = process.env.SO_DEFAULT_START_DATE || today();
   }
 
@@ -27,7 +32,7 @@ class StartDateFix implements Fix<PublicArtifact> {
   }
 
   execute(publicArtifact: PublicArtifact): PublicArtifact {
-    publicArtifact.publishingDate = this.defaultDate;
+    publicArtifact.publishingDate = this.timelineForFixer.timeFor(publicArtifact.details.name) || this.defaultDate;
 
     return publicArtifact;
   }

--- a/src/fixers/timelineForFixer.ts
+++ b/src/fixers/timelineForFixer.ts
@@ -1,0 +1,33 @@
+import * as _ from 'lodash';
+import {DevStoryArtifact} from '../models/devStory/devStoryArtifact';
+import {DatesParser} from '../parsers/datesParser';
+
+type TimelineItem = {
+  title: string;
+  startDate?: string;
+  endDate?: string;
+};
+
+export class TimelineForFixer {
+  private readonly timeline: TimelineItem[];
+
+  constructor(timelineItems: DevStoryArtifact[]) {
+    this.timeline = timelineItems.map((item): TimelineItem => {
+      const [startDate, endDate] = DatesParser.parse(item.time);
+      return {
+        title: item.title,
+        startDate,
+        endDate,
+      };
+    });
+  }
+
+  timeFor(name: string): string | undefined {
+    const itemIndex = _.findIndex(this.timeline, (element) => element.title === name);
+    const nearestStartDateIndex = _.findLastIndex(
+      this.timeline,
+      (element, elementIndex) => !_.isNil(element.startDate) && element.startDate !== '' && elementIndex < itemIndex,
+    );
+    return this.timeline[nearestStartDateIndex]?.startDate;
+  }
+}

--- a/src/parsers/experienceParser.ts
+++ b/src/parsers/experienceParser.ts
@@ -13,12 +13,9 @@ import {AchievementParser} from './achievementParser';
 import {JobsFixer} from '../fixers/jobsFixer';
 import {ProjectsFixer} from '../fixers/projectsFixer';
 import {PublicArtifactsFixer} from '../fixers/publicArtifactsFixer';
+import {TimelineForFixer} from '../fixers/timelineForFixer';
 
 export class ExperienceParser {
-  jobsFixer = new JobsFixer();
-  projectsFixer = new ProjectsFixer();
-  publicArtifactsFixer = new PublicArtifactsFixer();
-
   constructor(private readonly jobParser: JobParser) {}
 
   async parse($: CheerioAPI): Promise<Experience> {
@@ -37,10 +34,14 @@ export class ExperienceParser {
     const unknownArtifacts = timeLineItems.filter(this.isUnknownArtifact).map(AchievementParser.parse);
     const publicArtifacts = _.concat(timeLineArtifacts, stackOverflowAchievements, unknownArtifacts);
 
+    const timelineForFixer = new TimelineForFixer(timeLineItems);
+    const jobsFixer = new JobsFixer(timelineForFixer);
+    const projectsFixer = new ProjectsFixer(timelineForFixer);
+    const publicArtifactsFixer = new PublicArtifactsFixer(timelineForFixer);
     return {
-      jobs: this.jobsFixer.fix(jobs),
-      projects: this.projectsFixer.fix(projects),
-      publicArtifacts: this.publicArtifactsFixer.fix(publicArtifacts),
+      jobs: jobsFixer.fix(jobs),
+      projects: projectsFixer.fix(projects),
+      publicArtifacts: publicArtifactsFixer.fix(publicArtifacts),
     };
   }
 

--- a/src/tests/__snapshots__/devStoryScraper.test.ts.snap
+++ b/src/tests/__snapshots__/devStoryScraper.test.ts.snap
@@ -8662,7 +8662,7 @@ I lead a team building video and TV experiences for platforms such as Microsoft 
           "description": "I recently got frustrated with Bitly as a url shorter and decided to write my own simple alternative.",
           "name": "plinky - A bit like Bitly · martinpeck.com",
         },
-        "publishingDate": "2022-03-19",
+        "publishingDate": "2013-04-01",
         "type": "post",
       },
       Object {
@@ -8671,7 +8671,7 @@ I lead a team building video and TV experiences for platforms such as Microsoft 
           "description": "UPDATE: It’s been pointed out that the extension method RaiseToThePowerOf isn’t required. I’ve updated the C# solution to Problem 25 here, but left this post “as is”. This is part one of a three part…",
           "name": "Solving Problems in C# and F# – Part 2 | Peck's Blog — Peck's Blog",
         },
-        "publishingDate": "2022-03-19",
+        "publishingDate": "2013-04-01",
         "type": "post",
       },
       Object {
@@ -8680,7 +8680,7 @@ I lead a team building video and TV experiences for platforms such as Microsoft 
           "description": "On a recently snowboarding holiday I found myself having some decidedly geeky conversations with a good friend of mine, Giles Knap. Giles is currently learning F# and was extolling its virtues while…",
           "name": "Solving Problems in C# and F# – Part 1 | Peck's Blog — Peck's Blog",
         },
-        "publishingDate": "2022-03-19",
+        "publishingDate": "2013-04-01",
         "type": "post",
       },
       Object {
@@ -8689,7 +8689,7 @@ I lead a team building video and TV experiences for platforms such as Microsoft 
           "description": "I joined Code Club in Jan 2015 to head up their engineering team. However, way before this I was already voluneering for Code Club.",
           "name": "Volunteering for Code Club · martinpeck.com",
         },
-        "publishingDate": "2022-03-19",
+        "publishingDate": "2013-04-01",
         "type": "post",
       },
       Object {


### PR DESCRIPTION
When an item at the timeline has no date, we find the nearest item in the future and assign that date as the start date.

This PR closes #19 